### PR TITLE
Rename `screen` to `screen_rect` when the variable is a ScreenRect

### DIFF
--- a/libqtile/group.py
+++ b/libqtile/group.py
@@ -131,8 +131,8 @@ class _Group(CommandObject):
         self.current_layout = index
         hook.fire("layout_change", self.layouts[self.current_layout], self)
         self.layout_all()
-        screen = self.screen.get_rect()
-        self.layout.show(screen)
+        screen_rect = self.screen.get_rect()
+        self.layout.show(screen_rect)
 
     def use_next_layout(self):
         self.use_layout((self.current_layout + 1) % (len(self.layouts)))
@@ -153,15 +153,15 @@ class _Group(CommandObject):
                     x for x in self.windows
                     if x.floating and not x.minimized
                 ]
-                screen = self.screen.get_rect()
+                screen_rect = self.screen.get_rect()
                 if normal:
                     try:
-                        self.layout.layout(normal, screen)
+                        self.layout.layout(normal, screen_rect)
                     except Exception:
                         logger.exception("Exception in layout %s",
                                          self.layout.name)
                 if floating:
-                    self.floating_layout.layout(floating, screen)
+                    self.floating_layout.layout(floating, screen_rect)
                 if self.current_window and \
                         self.screen == self.qtile.current_screen:
                     self.current_window.focus(warp)
@@ -175,9 +175,9 @@ class _Group(CommandObject):
             # move all floating guys offset to new screen
             self.floating_layout.to_screen(self, self.screen)
             self.layout_all(warp=self.qtile.config.cursor_warp)
-            rect = self.screen.get_rect()
-            self.floating_layout.show(rect)
-            self.layout.show(rect)
+            screen_rect = self.screen.get_rect()
+            self.floating_layout.show(screen_rect)
+            self.layout.show(screen_rect)
         else:
             self.hide()
 

--- a/libqtile/layout/base.py
+++ b/libqtile/layout/base.py
@@ -51,10 +51,10 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         configurable.Configurable.__init__(self, **config)
         self.add_defaults(Layout.defaults)
 
-    def layout(self, windows, screen):
+    def layout(self, windows, screen_rect):
         assert windows, "let's eliminate unnecessary calls"
         for i in windows:
-            self.configure(i, screen)
+            self.configure(i, screen_rect)
 
     def finalize(self):
         pass
@@ -86,7 +86,7 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         elif name == "group":
             return self.group
 
-    def show(self, screen):
+    def show(self, screen_rect):
         """Called when layout is being shown"""
         pass
 
@@ -136,7 +136,7 @@ class Layout(CommandObject, configurable.Configurable, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         """Configure the layout
 
         This method should:
@@ -227,11 +227,11 @@ class SingleWindow(Layout):
         """Should return either visible window or None"""
         pass
 
-    def configure(self, win, screen):
+    def configure(self, win, screen_rect):
         if win is self._get_window():
             win.place(
-                screen.x, screen.y,
-                screen.width, screen.height,
+                screen_rect.x, screen_rect.y,
+                screen_rect.width, screen_rect.height,
                 0,
                 None,
             )
@@ -299,7 +299,7 @@ class Delegate(Layout):
         return focus
 
     @abstractmethod
-    def show(self, screen):
+    def show(self, screen_rect):
         """Tells the layout to show itself on the given ScreenRect"""
         pass
 

--- a/libqtile/layout/bsp.py
+++ b/libqtile/layout/bsp.py
@@ -203,9 +203,9 @@ class Bsp(Layout):
             node.client = None
             self.current = self.root
 
-    def configure(self, client, screen):
-        self.root.calc_geom(screen.x, screen.y, screen.width,
-                            screen.height)
+    def configure(self, client, screen_rect):
+        self.root.calc_geom(screen_rect.x, screen_rect.y, screen_rect.width,
+                            screen_rect.height)
         node = self.get_node(client)
         color = self.group.qtile.color_pixel(
             self.border_focus if client.has_focus else self.border_normal)

--- a/libqtile/layout/columns.py
+++ b/libqtile/layout/columns.py
@@ -210,7 +210,7 @@ class Columns(Layout):
             self.remove_column(c)
         return self.columns[self.current].cw
 
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         pos = 0
         for col in self.columns:
             if client in col:
@@ -229,8 +229,9 @@ class Columns(Layout):
             border = 0
         else:
             border = self.border_width
-        width = int(0.5 + col.width * screen.width * 0.01 / len(self.columns))
-        x = screen.x + int(0.5 + pos * screen.width * 0.01 / len(self.columns))
+        width = int(
+            0.5 + col.width * screen_rect.width * 0.01 / len(self.columns))
+        x = screen_rect.x + width
         if col.split:
             pos = 0
             for c in col:
@@ -238,8 +239,8 @@ class Columns(Layout):
                     break
                 pos += col.heights[c]
             height = int(
-                0.5 + col.heights[client] * screen.height * 0.01 / len(col))
-            y = screen.y + int(0.5 + pos * screen.height * 0.01 / len(col))
+                0.5 + col.heights[client] * screen_rect.height * 0.01 / len(col))
+            y = screen_rect.y + height
             client.place(
                 x,
                 y,
@@ -252,9 +253,9 @@ class Columns(Layout):
         elif client == col.cw:
             client.place(
                 x,
-                screen.y,
+                screen_rect.y,
                 width - 2 * border,
-                screen.height - 2 * border,
+                screen_rect.height - 2 * border,
                 border,
                 color,
                 margin=self.margin)

--- a/libqtile/layout/floating.py
+++ b/libqtile/layout/floating.py
@@ -177,7 +177,7 @@ class Floating(Layout):
     def blur(self):
         self.focused = None
 
-    def compute_client_position(self, client, screen):
+    def compute_client_position(self, client, screen_rect):
         """ recompute client.x and client.y, returning whether or not to place
         this client above other windows or not """
         above = False
@@ -188,27 +188,27 @@ class Floating(Layout):
             center_x = win.x + win.width / 2
             center_y = win.y + win.height / 2
         else:
-            center_x = screen.x + screen.width / 2
-            center_y = screen.y + screen.height / 2
+            center_x = screen_rect.x + screen_rect.width / 2
+            center_y = screen_rect.y + screen_rect.height / 2
             above = True
 
         x = center_x - client.width / 2
         y = center_y - client.height / 2
 
         # don't go off the right...
-        x = min(x, screen.x + screen.width)
+        x = min(x, screen_rect.x + screen_rect.width)
         # or left...
-        x = max(x, screen.x)
+        x = max(x, screen_rect.x)
         # or bottom...
-        y = min(y, screen.y + screen.height)
+        y = min(y, screen_rect.y + screen_rect.height)
         # or top
-        y = max(y, screen.y)
+        y = max(y, screen_rect.y)
 
         client.x = int(round(x))
         client.y = int(round(y))
         return above
 
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         if client.has_focus:
             bc = client.group.qtile.color_pixel(self.border_focus)
         else:
@@ -249,7 +249,7 @@ class Floating(Layout):
             client.float_y
         except AttributeError:
             # this window hasn't been placed before, let's put it in a sensible spot
-            above = self.compute_client_position(client, screen)
+            above = self.compute_client_position(client, screen_rect)
 
         client.place(
             client.x,

--- a/libqtile/layout/matrix.py
+++ b/libqtile/layout/matrix.py
@@ -99,7 +99,7 @@ class Matrix(_SimpleLayoutBase):
         If needed a new row in matrix is created"""
         return self.clients.append(client)
 
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         if client not in self.clients:
             return
         idx = self.clients.index(client)
@@ -111,10 +111,10 @@ class Matrix(_SimpleLayoutBase):
         else:
             px = self.group.qtile.color_pixel(self.border_normal)
         # calculate position and size
-        column_width = int(screen.width / float(self.columns))
-        row_height = int(screen.height / float(column_size))
-        xoffset = screen.x + col * column_width
-        yoffset = screen.y + row * row_height
+        column_width = int(screen_rect.width / float(self.columns))
+        row_height = int(screen_rect.height / float(column_size))
+        xoffset = screen_rect.x + col * column_width
+        yoffset = screen_rect.y + row * row_height
         win_width = column_width - 2 * self.border_width
         win_height = row_height - 2 * self.border_width
         # place

--- a/libqtile/layout/max.py
+++ b/libqtile/layout/max.py
@@ -26,9 +26,9 @@ class Max(_SimpleLayoutBase):
     """Maximized layout
 
     A simple layout that only displays one window at a time, filling the
-    screen. This is suitable for use on laptops and other devices with small
-    screens. Conceptually, the windows are managed as a stack, with commands to
-    switch to next and previous windows in the stack.
+    screen_rect. This is suitable for use on laptops and other devices with
+    small screens. Conceptually, the windows are managed as a stack, with
+    commands to switch to next and previous windows in the stack.
     """
 
     defaults = [("name", "max", "Name of this layout.")]
@@ -43,13 +43,13 @@ class Max(_SimpleLayoutBase):
     def add(self, client):
         return self.clients.add(client, 1)
 
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         if self.clients and client is self.clients.current_client:
             client.place(
-                screen.x,
-                screen.y,
-                screen.width,
-                screen.height,
+                screen_rect.x,
+                screen_rect.y,
+                screen_rect.width,
+                screen_rect.height,
                 0,
                 None
             )

--- a/libqtile/layout/slice.py
+++ b/libqtile/layout/slice.py
@@ -90,8 +90,8 @@ class Single(SingleWindow):
 class Slice(Delegate):
     """Slice layout
 
-    This layout cuts piece of screen and places a single window on that piece,
-    and delegates other window placement to other layout
+    This layout cuts piece of screen_rect and places a single window on that
+    piece, and delegates other window placement to other layout
     """
 
     defaults = [
@@ -121,8 +121,8 @@ class Slice(Delegate):
         res._window = None
         return res
 
-    def layout(self, windows, screen):
-        win, sub = self._get_screens(screen)
+    def layout(self, windows, screen_rect):
+        win, sub = self._get_screen_rects(screen_rect)
         self.delegate_layout(
             windows,
             {
@@ -131,12 +131,12 @@ class Slice(Delegate):
             }
         )
 
-    def show(self, screen):
-        win, sub = self._get_screens(screen)
+    def show(self, screen_rect):
+        win, sub = self._get_screen_rects(screen_rect)
         self._slice.show(win)
         self.fallback.show(sub)
 
-    def configure(self, win, screen):
+    def configure(self, win, screen_rect):
         raise NotImplementedError("Should not be called")
 
     def _get_layouts(self):
@@ -145,7 +145,7 @@ class Slice(Delegate):
     def _get_active_layout(self):
         return self.fallback  # always
 
-    def _get_screens(self, screen):
+    def _get_screen_rects(self, screen):
         if self.side == 'left':
             win, sub = screen.hsplit(self.width)
         elif self.side == 'right':

--- a/libqtile/layout/stack.py
+++ b/libqtile/layout/stack.py
@@ -47,7 +47,7 @@ class _WinStack(_ClientList):
 class Stack(Layout):
     """A layout composed of stacks of windows
 
-    The stack layout divides the screen horizontally into a set of stacks.
+    The stack layout divides the screen_rect horizontally into a set of stacks.
     Commands allow you to switch between stacks, to next and previous windows
     within a stack, and to split a stack to show all windows in the stack, or
     unsplit it to show only the current window.
@@ -205,7 +205,7 @@ class Stack(Layout):
             if n:
                 return n.cw
 
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         for i, s in enumerate(self.stacks):
             if client in s:
                 break
@@ -218,14 +218,14 @@ class Stack(Layout):
         else:
             px = self.group.qtile.color_pixel(self.border_normal)
 
-        column_width = int(screen.width / len(self.stacks))
-        xoffset = screen.x + i * column_width
+        column_width = int(screen_rect.width / len(self.stacks))
+        xoffset = screen_rect.x + i * column_width
         window_width = column_width - 2 * self.border_width
 
         if s.split:
-            column_height = int(screen.height / len(s))
+            column_height = int(screen_rect.height / len(s))
             window_height = column_height - 2 * self.border_width
-            yoffset = screen.y + s.index(client) * column_height
+            yoffset = screen_rect.y + s.index(client) * column_height
             client.place(
                 xoffset,
                 yoffset,
@@ -240,9 +240,9 @@ class Stack(Layout):
             if client == s.cw:
                 client.place(
                     xoffset,
-                    screen.y,
+                    screen_rect.y,
                     window_width,
-                    screen.height - 2 * self.border_width,
+                    screen_rect.height - 2 * self.border_width,
                     self.border_width,
                     px,
                     margin=self.margin,

--- a/libqtile/layout/tile.py
+++ b/libqtile/layout/tile.py
@@ -108,9 +108,9 @@ class Tile(_SimpleLayoutBase):
             self.clients.add(client, offset_to_current)
         self.reset_master()
 
-    def configure(self, client, screen):
-        screen_width = screen.width
-        screen_height = screen.height
+    def configure(self, client, screen_rect):
+        screen_width = screen_rect.width
+        screen_height = screen_rect.height
         border_width = self.border_width
         if self.clients and client in self.clients:
             pos = self.clients.index(client)
@@ -119,13 +119,13 @@ class Tile(_SimpleLayoutBase):
                     if len(self.slave_windows) or not self.expand \
                     else screen_width
                 h = screen_height // self.master
-                x = screen.x
-                y = screen.y + pos * h
+                x = screen_rect.x
+                y = screen_rect.y + pos * h
             else:
                 w = screen_width - int(screen_width * self.ratio)
                 h = screen_height // (len(self.slave_windows))
-                x = screen.x + int(screen_width * self.ratio)
-                y = screen.y + self.clients[self.master:].index(client) * h
+                x = screen_rect.x + int(screen_width * self.ratio)
+                y = screen_rect.y + self.clients[self.master:].index(client) * h
             if client.has_focus:
                 bc = self.group.qtile.color_pixel(self.border_focus)
             else:

--- a/libqtile/layout/tree.py
+++ b/libqtile/layout/tree.py
@@ -311,7 +311,7 @@ class TreeTab(Layout):
     """Tree Tab Layout
 
     This layout works just like Max but displays tree of the windows at the
-    left border of the screen, which allows you to overview all opened windows.
+    left border of the screen_rect, which allows you to overview all opened windows.
     It's designed to work with ``uzbl-browser`` but works with other windows
     too.
 
@@ -455,15 +455,15 @@ class TreeTab(Layout):
         del self._nodes[win]
         self.draw_panel()
 
-    def _create_panel(self, screen):
+    def _create_panel(self, screen_rect):
         self._panel = window.Internal.create(
             self.group.qtile,
-            screen.x,
-            screen.y,
+            screen_rect.x,
+            screen_rect.y,
             self.panel_width,
             100
         )
-        self._create_drawer(screen)
+        self._create_drawer(screen_rect)
         self._panel.handle_Expose = self._handle_Expose
         self._panel.handle_ButtonPress = self._handle_ButtonPress
         self.group.qtile.windows_map[self._panel.window.wid] = self._panel
@@ -485,11 +485,11 @@ class TreeTab(Layout):
         if node:
             self.group.focus(node.window, False)
 
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         if self._nodes and client is self._focused:
             client.place(
-                screen.x, screen.y,
-                screen.width, screen.height,
+                screen_rect.x, screen_rect.y,
+                screen_rect.width, screen_rect.height,
                 0,
                 None
             )
@@ -545,10 +545,10 @@ class TreeTab(Layout):
         d["client_trees"] = trees
         return d
 
-    def show(self, screen):
+    def show(self, screen_rect):
         if not self._panel:
-            self._create_panel(screen)
-        panel, body = screen.hsplit(self.panel_width)
+            self._create_panel(screen_rect)
+        panel, body = screen_rect.hsplit(self.panel_width)
         self._resize_panel(panel)
         self._panel.unhide()
 
@@ -714,13 +714,13 @@ class TreeTab(Layout):
         self.panel_width -= 10
         self.group.layout_all()
 
-    def _create_drawer(self, rect):
+    def _create_drawer(self, screen_rect):
         if self._drawer is None:
             self._drawer = drawer.Drawer(
                 self.group.qtile,
                 self._panel.window.wid,
                 self.panel_width,
-                rect.height
+                screen_rect.height
             )
         self._drawer.clear(self.bg_color)
         self._layout = self._drawer.textlayout(
@@ -732,18 +732,18 @@ class TreeTab(Layout):
             wrap=False
         )
 
-    def layout(self, windows, screen):
-        panel, body = screen.hsplit(self.panel_width)
+    def layout(self, windows, screen_rect):
+        panel, body = screen_rect.hsplit(self.panel_width)
         self._resize_panel(panel)
         Layout.layout(self, windows, body)
 
-    def _resize_panel(self, rect):
+    def _resize_panel(self, screen_rect):
         if self._panel:
             self._panel.place(
-                rect.x, rect.y,
-                rect.width, rect.height,
+                screen_rect.x, screen_rect.y,
+                screen_rect.width, screen_rect.height,
                 0,
                 None
             )
-            self._create_drawer(rect)
+            self._create_drawer(screen_rect)
             self.draw_panel()

--- a/libqtile/layout/verticaltile.py
+++ b/libqtile/layout/verticaltile.py
@@ -112,7 +112,7 @@ class VerticalTile(_SimpleLayoutBase):
         c.maximized = None
         return c
 
-    def configure(self, window, screen):
+    def configure(self, window, screen_rect):
         if self.clients and window in self.clients:
             n = len(self.clients)
             index = self.clients.index(window)
@@ -130,18 +130,18 @@ class VerticalTile(_SimpleLayoutBase):
 
             # width
             if n > 1:
-                width = screen.width - self.border_width * 2
+                width = screen_rect.width - self.border_width * 2
             else:
-                width = screen.width
+                width = screen_rect.width
 
             # height
             if n > 1:
-                main_area_height = int(screen.height * self.ratio)
-                sec_area_height = screen.height - main_area_height
+                main_area_height = int(screen_rect.height * self.ratio)
+                sec_area_height = screen_rect.height - main_area_height
 
                 main_pane_height = main_area_height - border_width * 2
                 sec_pane_height = sec_area_height // (n - 1) - border_width * 2
-                normal_pane_height = (screen.height // n) - (border_width * 2)
+                normal_pane_height = (screen_rect.height // n) - (border_width * 2)
 
                 if self.maximized:
                     if window is self.maximized:
@@ -151,10 +151,10 @@ class VerticalTile(_SimpleLayoutBase):
                 else:
                     height = normal_pane_height
             else:
-                height = screen.height
+                height = screen_rect.height
 
             # y
-            y = screen.y
+            y = screen_rect.y
 
             if n > 1:
                 if self.maximized:
@@ -167,7 +167,7 @@ class VerticalTile(_SimpleLayoutBase):
                     if index > self.clients.index(self.maximized):
                         y = y - sec_pane_height + main_pane_height
 
-            window.place(screen.x, y, width, height, border_width,
+            window.place(screen_rect.x, y, width, height, border_width,
                          border_color, margin=self.margin)
             window.unhide()
         else:

--- a/libqtile/layout/xmonad.py
+++ b/libqtile/layout/xmonad.py
@@ -44,8 +44,8 @@ class MonadTall(_SimpleLayoutBase):
     Main-Pane:
 
     A main pane that contains a single window takes up a vertical portion of
-    the screen based on the ratio setting. This ratio can be adjusted with the
-    ``cmd_grow_main`` and ``cmd_shrink_main`` or, while the main pane is in
+    the screen_rect based on the ratio setting. This ratio can be adjusted with
+    the ``cmd_grow_main`` and ``cmd_shrink_main`` or, while the main pane is in
     focus, ``cmd_grow`` and ``cmd_shrink``.
 
     ::
@@ -75,11 +75,11 @@ class MonadTall(_SimpleLayoutBase):
 
     Secondary-panes:
 
-    Occupying the rest of the screen are one or more secondary panes.  The
-    secondary panes will share the vertical space of the screen however they
-    can be resized at will with the ``cmd_grow`` and ``cmd_shrink`` methods.
-    The other secondary panes will adjust their sizes to smoothly fill all of
-    the space.
+    Occupying the rest of the screen_rect are one or more secondary panes.  The
+    secondary panes will share the vertical space of the screen_rect however
+    they can be resized at will with the ``cmd_grow`` and ``cmd_shrink``
+    methods.  The other secondary panes will adjust their sizes to smoothly fill
+    all of the space.
 
     ::
 
@@ -193,7 +193,7 @@ class MonadTall(_SimpleLayoutBase):
         c = _SimpleLayoutBase.clone(self, group)
         c.sizes = []
         c.relative_sizes = []
-        c.rect = group.screen.get_rect() if group.screen else None
+        c.screen_rect = group.screen.get_rect() if group.screen else None
         c.ratio = self.ratio
         c.align = self.align
         return c
@@ -267,9 +267,9 @@ class MonadTall(_SimpleLayoutBase):
             self._maximize_secondary()
         self.group.layout_all()
 
-    def configure(self, client, screen):
+    def configure(self, client, screen_rect):
         "Position client based on order and sizes"
-        self.screen_rect = screen
+        self.screen_rect = screen_rect
 
         # if no sizes or normalize flag is set, normalize
         if not self.relative_sizes or self.do_normalize:
@@ -300,12 +300,12 @@ class MonadTall(_SimpleLayoutBase):
             client.unhide()
             return
         cidx = self.clients.index(client)
-        self._configure_specific(client, screen, px, cidx)
+        self._configure_specific(client, screen_rect, px, cidx)
         client.unhide()
 
-    def _configure_specific(self, client, screen, px, cidx):
+    def _configure_specific(self, client, screen_rect, px, cidx):
         """Specific configuration for xmonad tall."""
-        self.screen_rect = screen
+        self.screen_rect = screen_rect
 
         # calculate main/secondary pane size
         width_main = int(self.screen_rect.width * self.ratio)
@@ -738,7 +738,7 @@ class MonadWide(MonadTall):
     Main-Pane:
 
     A main pane that contains a single window takes up a horizontal
-    portion of the screen based on the ratio setting. This ratio can be
+    portion of the screen_rect based on the ratio setting. This ratio can be
     adjusted with the ``cmd_grow_main`` and ``cmd_shrink_main`` or,
     while the main pane is in focus, ``cmd_grow`` and ``cmd_shrink``.
 
@@ -770,8 +770,8 @@ class MonadWide(MonadTall):
 
     Secondary-panes:
 
-    Occupying the rest of the screen are one or more secondary panes.
-    The secondary panes will share the horizontal space of the screen
+    Occupying the rest of the screen_rect are one or more secondary panes.
+    The secondary panes will share the horizontal space of the screen_rect
     however they can be resized at will with the ``cmd_grow`` and
     ``cmd_shrink`` methods. The other secondary panes will adjust their
     sizes to smoothly fill all of the space.
@@ -864,9 +864,9 @@ class MonadWide(MonadTall):
         else:
             self._grow_secondary(maxed_size)
 
-    def _configure_specific(self, client, screen, px, cidx):
+    def _configure_specific(self, client, screen_rect, px, cidx):
         """Specific configuration for xmonad wide."""
-        self.screen_rect = screen
+        self.screen_rect = screen_rect
 
         # calculate main/secondary column widths
         height_main = int(self.screen_rect.height * self.ratio)

--- a/libqtile/layout/zoomy.py
+++ b/libqtile/layout/zoomy.py
@@ -48,8 +48,8 @@ class Zoomy(_SimpleLayoutBase):
     def add(self, client):
         self.clients.append_head(client)
 
-    def configure(self, client, screen):
-        left, right = screen.hsplit(screen.width - self.columnwidth)
+    def configure(self, client, screen_rect):
+        left, right = screen_rect.hsplit(screen_rect.width - self.columnwidth)
         if client is self.clients.current_client:
             client.place(
                 left.x,


### PR DESCRIPTION
Previously, we had screen meaning two different things, which was
confusing.